### PR TITLE
refactor: Follow와 Member 레이어의 책임을 분리한다.

### DIFF
--- a/backend/src/main/java/com/example/backend/business/core/member/infrastructure/follow/command/FollowCommandRepository.java
+++ b/backend/src/main/java/com/example/backend/business/core/member/infrastructure/follow/command/FollowCommandRepository.java
@@ -1,9 +1,12 @@
 package com.example.backend.business.core.member.infrastructure.follow.command;
 
+import com.example.backend.business.core.member.entity.values.MemberId;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
+
+import static com.example.backend.business.core.member.entity.QFollow.follow;
 
 @Repository
 public class FollowCommandRepository {
@@ -14,5 +17,11 @@ public class FollowCommandRepository {
     public FollowCommandRepository(JPAQueryFactory queryFactory, EntityManager entityManager) {
         this.queryFactory = queryFactory;
         this.entityManager = entityManager;
+    }
+
+    public void unfollow(MemberId sourceId, MemberId targetId) {
+        queryFactory.delete(follow)
+                .where(follow.source.memberId.eq(sourceId.getMemberId()).and(follow.target.memberId.eq(targetId.getMemberId())))
+                .execute();
     }
 }

--- a/backend/src/main/java/com/example/backend/business/core/member/infrastructure/follow/query/FollowQueryRepository.java
+++ b/backend/src/main/java/com/example/backend/business/core/member/infrastructure/follow/query/FollowQueryRepository.java
@@ -1,9 +1,20 @@
 package com.example.backend.business.core.member.infrastructure.follow.query;
 
+import com.example.backend.business.core.common.values.Cursor;
+import com.example.backend.business.core.member.entity.Follow;
+import com.example.backend.business.core.member.entity.Member;
+import com.example.backend.business.core.member.entity.values.MemberId;
+import com.example.backend.business.web.member.presentation.member.dto.response.FollowHistoryExistResponse;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.backend.business.core.member.entity.QFollow.follow;
+import static com.example.backend.business.core.member.entity.QMember.member;
 
 @Repository
 public class FollowQueryRepository {
@@ -14,5 +25,69 @@ public class FollowQueryRepository {
     public FollowQueryRepository(JPAQueryFactory queryFactory, EntityManager entityManager) {
         this.queryFactory = queryFactory;
         this.entityManager = entityManager;
+    }
+
+    public FollowHistoryExistResponse findFollowHistoryById(MemberId sourceId, MemberId targetId) {
+        Integer result = queryFactory.selectOne()
+                .from(follow)
+                .where(follow.source.memberId.eq(sourceId.getMemberId()).and(follow.target.memberId.eq(targetId.getMemberId())))
+                .fetchFirst();
+        return new FollowHistoryExistResponse(result);
+    }
+
+    public List<Follow> findFollowerListById(MemberId memberId, Cursor cursor) {
+        if (cursor.isFirstPage()) {
+            return queryFactory.selectFrom(follow)
+                    .join(follow.source, member)
+                    .fetchJoin()
+                    .where(follow.target.memberId.eq(memberId.getMemberId()))
+                    .limit(cursor.getPageSize() + 1)
+                    .orderBy(member.memberId.desc())
+                    .fetch();
+        }
+        return queryFactory.selectFrom(follow)
+                .join(follow.source, member)
+                .fetchJoin()
+                .where(follow.target.memberId.eq(memberId.getMemberId())
+                        .and(follow.source.memberId.lt(cursor.getNext())))
+                .limit(cursor.getPageSize() + 1)
+                .orderBy(member.memberId.desc())
+                .fetch();
+    }
+
+    public List<Long> findFollowOrNot(MemberId memberId, List<Long> targetIds) {
+        List<Follow> followerList = queryFactory.selectFrom(follow)
+                .join(follow.source, member)
+                .on(follow.target.memberId.in(targetIds))
+                .where(follow.source.memberId.eq(memberId.getMemberId()))
+                .fetch();
+
+        if (followerList.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return followerList.stream()
+                .map(Follow::getTarget)
+                .map(Member::getMemberId)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    public List<Follow> findFollowingList(MemberId memberId, Cursor cursor) {
+        if (cursor.isFirstPage()) {
+            return queryFactory.selectFrom(follow)
+                    .join(follow.target, member)
+                    .fetchJoin()
+                    .where(follow.source.memberId.eq(memberId.getMemberId()))
+                    .limit(cursor.getPageSize() + 1)
+                    .orderBy(member.memberId.desc())
+                    .fetch();
+        }
+        return queryFactory.selectFrom(follow)
+                .join(follow.target, member)
+                .fetchJoin()
+                .where(follow.source.memberId.lt(cursor.getNext()))
+                .limit(cursor.getPageSize() + 1)
+                .orderBy(member.memberId.desc())
+                .fetch();
     }
 }

--- a/backend/src/main/java/com/example/backend/business/core/member/infrastructure/member/command/MemberQueryDslCommandRepository.java
+++ b/backend/src/main/java/com/example/backend/business/core/member/infrastructure/member/command/MemberQueryDslCommandRepository.java
@@ -1,13 +1,10 @@
 package com.example.backend.business.core.member.infrastructure.member.command;
 
 import com.example.backend.business.core.member.entity.Member;
-import com.example.backend.business.core.member.entity.values.MemberId;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
-
-import static com.example.backend.business.core.member.entity.QFollow.follow;
 
 @Repository
 public class MemberQueryDslCommandRepository {
@@ -23,11 +20,5 @@ public class MemberQueryDslCommandRepository {
     public Member save(Member member) {
         entityManager.persist(member);
         return entityManager.find(Member.class, member.getMemberId());
-    }
-
-    public void unfollow(MemberId sourceId, MemberId targetId) {
-        queryFactory.delete(follow)
-                .where(follow.source.memberId.eq(sourceId.getMemberId()).and(follow.target.memberId.eq(targetId.getMemberId())))
-                .execute();
     }
 }

--- a/backend/src/main/java/com/example/backend/business/core/member/infrastructure/member/query/MemberQueryDslQueryRepository.java
+++ b/backend/src/main/java/com/example/backend/business/core/member/infrastructure/member/query/MemberQueryDslQueryRepository.java
@@ -43,7 +43,7 @@ public class MemberQueryDslQueryRepository {
                 .fetchOne());
     }
 
-    public Optional<Member> findMemberByNickName(NickName nickName) {
+    public Optional<Member> findByNickName(NickName nickName) {
         return Optional.ofNullable(queryFactory.selectFrom(member)
                 .where(member.nickName.eq(nickName).and(member.deleted.eq(FALSE)))
                 .fetchOne());

--- a/backend/src/main/java/com/example/backend/business/web/comment/facade/CommentCommandFacade.java
+++ b/backend/src/main/java/com/example/backend/business/web/comment/facade/CommentCommandFacade.java
@@ -64,7 +64,7 @@ public class CommentCommandFacade {
                 Thread.sleep(500);
             }
             Study findStudy = studyQueryServices.findStudyById(studyId).orElseThrow(() -> new BusinessException(StudyTypeException.STUDY_NOT_FOUND_EXCEPTION));
-            Member writer = memberQueryService.findMemberById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+            Member writer = memberQueryService.findById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
             return commentCommandService.writeComment(writer, findStudy, content);
         } catch (InterruptedException e) {
             throw new RuntimeException();
@@ -102,7 +102,7 @@ public class CommentCommandFacade {
             if (!available) {
                 Thread.sleep(500);
             }
-            Member writer = memberQueryService.findMemberById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+            Member writer = memberQueryService.findById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
             Comment newReComment = commentCommandService.writeReComment(writer, commentParentId, content);
             commentQueryServices.existCommentParent(commentParentId);
             return newReComment;
@@ -118,7 +118,7 @@ public class CommentCommandFacade {
                               CommentId commentId,
                               CommentContent content) {
 
-        Member writer = memberQueryService.findMemberById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+        Member writer = memberQueryService.findById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
         commentCommandService.updateComment(writer.getMemberIdAsValue(), commentId, content);
     }
 
@@ -129,7 +129,7 @@ public class CommentCommandFacade {
                                 CommentId commentId,
                                 CommentContent content) {
 
-        Member writer = memberQueryService.findMemberById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+        Member writer = memberQueryService.findById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
 
         commentCommandService.updateReComment(writer.getMemberIdAsValue(), commentId, content);
         existValidation(studyId, commentParentId);
@@ -161,7 +161,7 @@ public class CommentCommandFacade {
                 Thread.sleep(500);
             }
 
-            Member writer = memberQueryService.findMemberById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+            Member writer = memberQueryService.findById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
             commentCommandService.deleteComment(writer.getMemberIdAsValue(), commentId);
         } catch (InterruptedException e) {
             throw new RuntimeException();
@@ -196,7 +196,7 @@ public class CommentCommandFacade {
                 Thread.sleep(500);
             }
 
-            Member writer = memberQueryService.findMemberById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+            Member writer = memberQueryService.findById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
             commentCommandService.deleteReComment(writer.getMemberIdAsValue(), commentParentId, commentId);
             existValidation(studyId, commentParentId);
         } catch (InterruptedException e) {

--- a/backend/src/main/java/com/example/backend/business/web/like/facade/LikeCommandFacade.java
+++ b/backend/src/main/java/com/example/backend/business/web/like/facade/LikeCommandFacade.java
@@ -52,7 +52,7 @@ public class LikeCommandFacade {
             }
 
             Study findStudy = studyQueryServices.findStudyById(studyId).orElseThrow(() -> new BusinessException(StudyTypeException.STUDY_NOT_FOUND_EXCEPTION));
-            Member findMember= memberQueryService.findMemberById(memberId).orElseThrow(()->new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+            Member findMember= memberQueryService.findById(memberId).orElseThrow(()->new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
             LikeClicked likeClicked = likeQueryService.exist(memberId, studyId);
 
             likeCommandService.updateLike(likeClicked, memberId, findStudy);

--- a/backend/src/main/java/com/example/backend/business/web/member/application/follow/FollowCommandService.java
+++ b/backend/src/main/java/com/example/backend/business/web/member/application/follow/FollowCommandService.java
@@ -1,9 +1,39 @@
 package com.example.backend.business.web.member.application.follow;
 
+import com.example.backend.business.core.member.entity.Follow;
+import com.example.backend.business.core.member.entity.FollowHistory;
+import com.example.backend.business.core.member.entity.Member;
+import com.example.backend.business.core.member.infrastructure.follow.command.FollowCommandRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class FollowCommandService {
+
+    private final FollowCommandRepository followCommandRepository;
+
+    @Transactional
+    public void updateFollow(FollowHistory followHistory,
+                             Member source,
+                             Member target) {
+
+        if (followHistory.exist()) {
+            followCommandRepository.unfollow(source.getMemberIdAsValue(), target.getMemberIdAsValue());
+            updateUnfollow(source, target);
+            return;
+        }
+        updateFollow(source, target);
+    }
+
+    private void updateUnfollow(Member source, Member target) {
+        source.decreaseFollowingCount();
+        target.decraseFollowerCount();
+    }
+
+    private void updateFollow(Member source, Member target) {
+        source.follow(new Follow(source, target));
+        target.increaseFollowerCount();
+    }
 }

--- a/backend/src/main/java/com/example/backend/business/web/member/application/follow/FollowQueryService.java
+++ b/backend/src/main/java/com/example/backend/business/web/member/application/follow/FollowQueryService.java
@@ -1,9 +1,39 @@
 package com.example.backend.business.web.member.application.follow;
 
+import com.example.backend.business.core.common.values.Cursor;
+import com.example.backend.business.core.member.entity.values.Followers;
+import com.example.backend.business.core.member.entity.values.MemberId;
+import com.example.backend.business.core.member.infrastructure.follow.query.FollowQueryRepository;
+import com.example.backend.business.web.member.presentation.member.dto.response.FollowHistoryExistResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class FollowQueryService {
+
+    private final FollowQueryRepository followQueryRepository;
+
+    @Transactional(readOnly = true)
+    public Followers findFollowerListById(MemberId memberId, Cursor cursor) {
+        return Followers.from(followQueryRepository.findFollowerListById(memberId, cursor));
+    }
+
+    @Transactional(readOnly = true)
+    public FollowHistoryExistResponse findFollowHistoryById(MemberId sourceId, MemberId targetId) {
+        return followQueryRepository.findFollowHistoryById(sourceId, targetId);
+    }
+
+    @Transactional(readOnly = true)
+    public Followers findFollowingListById(MemberId memberId, Cursor cursor) {
+        return Followers.from(followQueryRepository.findFollowingList(memberId, cursor));
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> findMyFollowerList(MemberId memberId, List<Long> targetIds) {
+        return followQueryRepository.findFollowOrNot(memberId, targetIds);
+    }
 }

--- a/backend/src/main/java/com/example/backend/business/web/member/application/member/MemberCommandService.java
+++ b/backend/src/main/java/com/example/backend/business/web/member/application/member/MemberCommandService.java
@@ -1,8 +1,6 @@
 package com.example.backend.business.web.member.application.member;
 
 import com.example.backend.business.core.common.District;
-import com.example.backend.business.core.member.entity.Follow;
-import com.example.backend.business.core.member.entity.FollowHistory;
 import com.example.backend.business.core.member.entity.Member;
 import com.example.backend.business.core.member.entity.values.BirthDate;
 import com.example.backend.business.core.member.entity.values.BlogUrl;
@@ -24,21 +22,6 @@ public class MemberCommandService {
     @Transactional
     public Member save(Member member) {
         return memberJpaRepository.save(member);
-    }
-
-    @Transactional
-    public void updateFollow(FollowHistory followHistory,
-                             Member source,
-                             Member target) {
-
-        if (followHistory.exist()) {
-            memberQueryRepository.unfollow(source.getMemberIdAsValue(), target.getMemberIdAsValue());
-            source.decreaseFollowingCount();
-            target.decraseFollowerCount();
-            return;
-        }
-        source.follow(new Follow(source, target));
-        target.increaseFollowerCount();
     }
 
     @Transactional

--- a/backend/src/main/java/com/example/backend/business/web/member/application/member/MemberQueryService.java
+++ b/backend/src/main/java/com/example/backend/business/web/member/application/member/MemberQueryService.java
@@ -1,19 +1,15 @@
 package com.example.backend.business.web.member.application.member;
 
-import com.example.backend.business.core.common.values.Cursor;
 import com.example.backend.business.core.member.entity.Member;
-import com.example.backend.business.core.member.entity.values.Followers;
 import com.example.backend.business.core.member.entity.values.GithubId;
 import com.example.backend.business.core.member.entity.values.MemberId;
 import com.example.backend.business.core.member.entity.values.NickName;
 import com.example.backend.business.core.member.infrastructure.member.query.MemberQueryDslQueryRepository;
-import com.example.backend.business.web.member.presentation.member.dto.response.FollowHistoryExistResponse;
 import com.example.backend.business.web.member.presentation.member.dto.response.NickNameExistResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -23,7 +19,7 @@ public class MemberQueryService {
     private final MemberQueryDslQueryRepository memberQueryDslQueryRepository;
 
     @Transactional(readOnly = true)
-    public Optional<Member> findMemberById(MemberId memberId) {
+    public Optional<Member> findById(MemberId memberId) {
         return memberQueryDslQueryRepository.findById(memberId);
     }
 
@@ -33,8 +29,8 @@ public class MemberQueryService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<Member> findMemberByNickName(NickName nickName) {
-        return memberQueryDslQueryRepository.findMemberByNickName(nickName);
+    public Optional<Member> findByNickName(NickName nickName) {
+        return memberQueryDslQueryRepository.findByNickName(nickName);
     }
 
     @Transactional(readOnly = true)
@@ -43,27 +39,7 @@ public class MemberQueryService {
     }
 
     @Transactional(readOnly = true)
-    public FollowHistoryExistResponse findFollowHistoryById(MemberId sourceId, MemberId targetId) {
-        return memberQueryDslQueryRepository.findFollowHistoryById(sourceId, targetId);
-    }
-
-    @Transactional(readOnly = true)
     public NickNameExistResponse validateDuplicatedNickName(NickName nickName) {
         return memberQueryDslQueryRepository.validateDuplicatedNickName(nickName);
-    }
-
-    @Transactional(readOnly = true)
-    public Followers findFollowerListById(MemberId memberId, Cursor cursor) {
-        return Followers.from(memberQueryDslQueryRepository.findFollowerListById(memberId, cursor));
-    }
-
-    @Transactional(readOnly = true)
-    public List<Long> findMyFollowerList(MemberId memberId, List<Long> targetIds) {
-        return memberQueryDslQueryRepository.findFollowOrNot(memberId, targetIds);
-    }
-
-    @Transactional(readOnly = true)
-    public Followers findFollowingListById(MemberId memberId, Cursor cursor) {
-        return Followers.from(memberQueryDslQueryRepository.findFollowingList(memberId, cursor));
     }
 }

--- a/backend/src/main/java/com/example/backend/business/web/member/facade/follow/FollowCommandFacade.java
+++ b/backend/src/main/java/com/example/backend/business/web/member/facade/follow/FollowCommandFacade.java
@@ -1,9 +1,48 @@
 package com.example.backend.business.web.member.facade.follow;
 
+import com.example.backend.business.core.member.entity.Member;
+import com.example.backend.business.core.member.entity.values.MemberId;
+import com.example.backend.business.web.member.application.follow.FollowCommandService;
+import com.example.backend.business.web.member.application.follow.FollowQueryService;
+import com.example.backend.business.web.member.application.member.MemberQueryService;
+import com.example.backend.business.web.member.presentation.member.dto.response.FollowHistoryExistResponse;
+import com.example.backend.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.example.backend.common.exception.member.MemberTypeException.MEMBER_NOT_FOUND_EXCEPTION;
 
 @Component
 @RequiredArgsConstructor
 public class FollowCommandFacade {
+
+    private final FollowQueryService followQueryService;
+    private final FollowCommandService followCommandService;
+    private final MemberQueryService memberQueryService;
+    private final RedissonClient redissonClient;
+
+    @Transactional
+    public void updateFollow(MemberId sourceId, MemberId targetId) {
+        RLock lock = redissonClient.getLock(targetId.getMemberId().toString());
+        try {
+            boolean available = lock.tryLock(3, 1, TimeUnit.SECONDS);
+
+            if (!available) {
+                Thread.sleep(1000);
+            }
+
+            Member source = memberQueryService.findById(sourceId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+            Member target = memberQueryService.findById(targetId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+            FollowHistoryExistResponse followHistoryResponse = followQueryService.findFollowHistoryById(source.getMemberIdAsValue(), target.getMemberIdAsValue());
+
+            followCommandService.updateFollow(followHistoryResponse.getFollowHistory(), source, target);
+        } catch (InterruptedException e) {
+            lock.unlock();
+        }
+    }
 }

--- a/backend/src/main/java/com/example/backend/business/web/member/facade/follow/FollowQueryFacade.java
+++ b/backend/src/main/java/com/example/backend/business/web/member/facade/follow/FollowQueryFacade.java
@@ -1,10 +1,39 @@
 package com.example.backend.business.web.member.facade.follow;
 
+import com.example.backend.business.core.common.values.Cursor;
+import com.example.backend.business.core.member.entity.values.Followers;
+import com.example.backend.business.core.member.entity.values.MemberId;
+import com.example.backend.business.web.member.application.follow.FollowQueryService;
+import com.example.backend.business.web.member.presentation.member.dto.response.FollowHistoryExistResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class FollowQueryFacade {
 
+    private final FollowQueryService followQueryService;
+
+    @Transactional(readOnly = true)
+    public FollowHistoryExistResponse findFollowHistoryById(MemberId sourceId, MemberId targetId) {
+        return followQueryService.findFollowHistoryById(sourceId, targetId);
+    }
+
+    @Transactional(readOnly = true)
+    public Followers findFollowerListById(MemberId memberId, Cursor cursor) {
+        return followQueryService.findFollowerListById(memberId, cursor);
+    }
+
+    @Transactional(readOnly = true)
+    public Followers findFollowingListById(MemberId memberId, Cursor cursor) {
+        return followQueryService.findFollowingListById(memberId, cursor);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> findMyFollowList(MemberId memberId, List<Long> ids) {
+        return followQueryService.findMyFollowerList(memberId, ids);
+    }
 }

--- a/backend/src/main/java/com/example/backend/business/web/member/facade/member/MemberCommandFacade.java
+++ b/backend/src/main/java/com/example/backend/business/web/member/facade/member/MemberCommandFacade.java
@@ -9,15 +9,10 @@ import com.example.backend.business.core.member.entity.values.MemberId;
 import com.example.backend.business.core.member.entity.values.NickName;
 import com.example.backend.business.web.member.application.member.MemberCommandService;
 import com.example.backend.business.web.member.application.member.MemberQueryService;
-import com.example.backend.business.web.member.presentation.member.dto.response.FollowHistoryExistResponse;
 import com.example.backend.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.concurrent.TimeUnit;
 
 import static com.example.backend.common.exception.member.MemberTypeException.MEMBER_NOT_FOUND_EXCEPTION;
 
@@ -27,7 +22,6 @@ public class MemberCommandFacade {
 
     private final MemberCommandService memberCommandService;
     private final MemberQueryService memberQueryService;
-    private final RedissonClient redissonClient;
 
     @Transactional
     public void updateProfile(MemberId memberId,
@@ -36,40 +30,19 @@ public class MemberCommandFacade {
                               BirthDate birthDate,
                               Introduction introduction) {
 
-        Member findMember = memberQueryService.findMemberById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+        Member findMember = memberQueryService.findById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
         memberCommandService.updateProfile(findMember, blogUrl, district, birthDate, introduction);
     }
 
     @Transactional
     public void updateNickName(MemberId memberId, NickName nickName) {
-        Member findMember = memberQueryService.findMemberById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+        Member findMember = memberQueryService.findById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
         memberCommandService.updatNickName(findMember, nickName);
     }
 
     @Transactional
     public void withdrawalMembership(MemberId memberId) {
-        Member findMember = memberQueryService.findMemberById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+        Member findMember = memberQueryService.findById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
         memberCommandService.delete(findMember);
-    }
-
-    @Transactional
-    public void updateFollow(MemberId sourceId, MemberId targetId) {
-        RLock lock = redissonClient.getLock(targetId.getMemberId().toString());
-        try {
-            boolean available = lock.tryLock(3, 100, TimeUnit.SECONDS);
-
-            if (!available) {
-                Thread.sleep(200);
-            }
-
-            Member source = memberQueryService.findMemberById(sourceId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
-            Member target = memberQueryService.findMemberById(targetId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
-
-            FollowHistoryExistResponse followHistoryResponse = memberQueryService.findFollowHistoryById(source.getMemberIdAsValue(), target.getMemberIdAsValue());
-
-            memberCommandService.updateFollow(followHistoryResponse.getFollowHistory(), source, target);
-        } catch (InterruptedException e) {
-            lock.unlock();
-        }
     }
 }

--- a/backend/src/main/java/com/example/backend/business/web/member/facade/member/MemberQueryFacade.java
+++ b/backend/src/main/java/com/example/backend/business/web/member/facade/member/MemberQueryFacade.java
@@ -1,19 +1,14 @@
 package com.example.backend.business.web.member.facade.member;
 
-import com.example.backend.business.core.common.values.Cursor;
 import com.example.backend.business.core.member.entity.Member;
-import com.example.backend.business.core.member.entity.values.Followers;
 import com.example.backend.business.core.member.entity.values.MemberId;
 import com.example.backend.business.core.member.entity.values.NickName;
 import com.example.backend.business.web.member.application.member.MemberQueryService;
-import com.example.backend.business.web.member.presentation.member.dto.response.FollowHistoryExistResponse;
 import com.example.backend.business.web.member.presentation.member.dto.response.NickNameExistResponse;
 import com.example.backend.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 import static com.example.backend.common.exception.member.MemberTypeException.MEMBER_NOT_FOUND_EXCEPTION;
 
@@ -24,38 +19,18 @@ public class MemberQueryFacade {
     private final MemberQueryService memberQueryService;
 
     @Transactional(readOnly = true)
-    public Member findMemberById(MemberId memberId) {
-        return memberQueryService.findMemberById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+    public Member findById(MemberId memberId) {
+        return memberQueryService.findById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
     }
 
     @Transactional(readOnly = true)
-    public Member findMemberByNickName(NickName nickName) {
-        return memberQueryService.findMemberByNickName(nickName).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+    public Member findByNickName(NickName nickName) {
+        return memberQueryService.findByNickName(nickName).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
     }
 
     @Transactional(readOnly = true)
     public NickNameExistResponse validateDuplicatedNickName(MemberId memberId, NickName nickName) {
-        Member findMember = memberQueryService.findMemberById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+        Member findMember = memberQueryService.findById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
         return memberQueryService.validateDuplicatedNickName(nickName);
-    }
-
-    @Transactional(readOnly = true)
-    public Followers findFollowerListById(MemberId memberId, Cursor cursor) {
-        return memberQueryService.findFollowerListById(memberId, cursor);
-    }
-
-    @Transactional(readOnly = true)
-    public FollowHistoryExistResponse findFollowHistoryById(MemberId sourceId, MemberId targetId) {
-        return memberQueryService.findFollowHistoryById(sourceId, targetId);
-    }
-
-    @Transactional(readOnly = true)
-    public List<Long> findMyFollowList(MemberId memberId, List<Long> ids) {
-        return memberQueryService.findMyFollowerList(memberId, ids);
-    }
-
-    @Transactional(readOnly = true)
-    public Followers findFollowingListById(MemberId memberId, Cursor cursor) {
-        return memberQueryService.findFollowingListById(memberId, cursor);
     }
 }

--- a/backend/src/main/java/com/example/backend/business/web/member/presentation/follow/FollowCommandController.java
+++ b/backend/src/main/java/com/example/backend/business/web/member/presentation/follow/FollowCommandController.java
@@ -1,7 +1,7 @@
 package com.example.backend.business.web.member.presentation.follow;
 
 import com.example.backend.business.core.member.entity.values.MemberId;
-import com.example.backend.business.web.member.facade.member.MemberCommandFacade;
+import com.example.backend.business.web.member.facade.follow.FollowCommandFacade;
 import com.example.backend.business.web.member.presentation.member.dto.request.FollowRequest;
 import com.example.backend.common.login.annotation.Authenticated;
 import com.example.backend.common.login.model.authentication.AuthenticatedMember;
@@ -17,13 +17,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class FollowCommandController {
 
-    private final MemberCommandFacade memberCommandFacade;
+    private final FollowCommandFacade followCommandFacade;
 
     @PostMapping("/following")
     public ResponseEntity<Void> updateFollow(@Authenticated AuthenticatedMember authenticatedMember,
                                              @RequestBody FollowRequest request) {
 
-        memberCommandFacade.updateFollow(
+        followCommandFacade.updateFollow(
                 authenticatedMember.getAuthenticatedIdAsValue(),
                 MemberId.from(request.getTargetId())
         );

--- a/backend/src/main/java/com/example/backend/business/web/member/presentation/follow/FollowQueryController.java
+++ b/backend/src/main/java/com/example/backend/business/web/member/presentation/follow/FollowQueryController.java
@@ -1,13 +1,11 @@
 package com.example.backend.business.web.member.presentation.follow;
 
 import com.example.backend.business.core.common.values.Cursor;
-import com.example.backend.business.core.member.entity.Member;
 import com.example.backend.business.core.member.entity.values.Followers;
 import com.example.backend.business.core.member.entity.values.MemberId;
-import com.example.backend.business.web.member.facade.member.MemberQueryFacade;
+import com.example.backend.business.web.member.facade.follow.FollowQueryFacade;
 import com.example.backend.business.web.member.presentation.member.dto.response.FollowHistoryExistResponse;
 import com.example.backend.business.web.member.presentation.member.dto.response.FollowerListResponse;
-import com.example.backend.business.web.member.presentation.member.dto.response.MemberInformationHoverResponse;
 import com.example.backend.common.configuration.common.page.CursorPageable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -29,17 +27,7 @@ import static com.example.backend.common.api.ApiUtils.getMemberIdAsValue;
 @RequiredArgsConstructor
 public class FollowQueryController {
 
-    private final MemberQueryFacade memberQueryFacade;
-
-    @GetMapping("/{memberId}/hover-info")
-    public ResponseEntity<MemberInformationHoverResponse> findMemberById(@PathVariable Long memberId) {
-
-        Member findMember = memberQueryFacade.findMemberById(
-                MemberId.from(memberId)
-        );
-
-        return ResponseEntity.ok(MemberInformationHoverResponse.of(findMember));
-    }
+    private final FollowQueryFacade followQueryFacade;
 
     @GetMapping("/{memberId}/friendship/follow-history")
     public ResponseEntity<FollowHistoryExistResponse> findFollowHistoryById(@PathVariable Long memberId,
@@ -49,7 +37,7 @@ public class FollowQueryController {
             return ResponseEntity.ok(FollowHistoryExistResponse.of(NON_EXIST));
         }
 
-        FollowHistoryExistResponse response = memberQueryFacade.findFollowHistoryById(
+        FollowHistoryExistResponse response = followQueryFacade.findFollowHistoryById(
                 getMemberIdAsValue(httpServletRequest),
                 MemberId.from(memberId)
         );
@@ -62,7 +50,7 @@ public class FollowQueryController {
                                                                   @CursorPageable Cursor cursor,
                                                                   HttpServletRequest httpServletRequest) {
 
-        Followers followingList = memberQueryFacade.findFollowingListById(
+        Followers followingList = followQueryFacade.findFollowingListById(
                 MemberId.from(memberId),
                 cursor
         );
@@ -86,7 +74,7 @@ public class FollowQueryController {
                                                                  @CursorPageable Cursor cursor,
                                                                  HttpServletRequest httpServletRequest) {
 
-        Followers followerList = memberQueryFacade.findFollowerListById(
+        Followers followerList = followQueryFacade.findFollowerListById(
                 MemberId.from(memberId),
                 cursor
         );
@@ -106,7 +94,7 @@ public class FollowQueryController {
     }
 
     private List<Long> getMyFollwerList(MemberId memberId, List<Long> getTargetIds) {
-        return memberQueryFacade.findMyFollowList(
+        return followQueryFacade.findMyFollowList(
                 memberId,
                 getTargetIds
         );

--- a/backend/src/main/java/com/example/backend/business/web/member/presentation/member/MemberQueryController.java
+++ b/backend/src/main/java/com/example/backend/business/web/member/presentation/member/MemberQueryController.java
@@ -1,6 +1,7 @@
 package com.example.backend.business.web.member.presentation.member;
 
 import com.example.backend.business.core.member.entity.Member;
+import com.example.backend.business.core.member.entity.values.MemberId;
 import com.example.backend.business.core.member.entity.values.NickName;
 import com.example.backend.business.web.member.facade.member.MemberQueryFacade;
 import com.example.backend.business.web.member.presentation.member.dto.response.MemberInformationHoverResponse;
@@ -11,6 +12,7 @@ import com.example.backend.common.login.model.authentication.AuthenticatedMember
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,11 +29,21 @@ public class MemberQueryController {
     @GetMapping("/my-profile")
     public ResponseEntity<MemberProfileResponse> findMemberById(@Authenticated AuthenticatedMember authenticatedMember) {
 
-        Member findMember = memberQueryFacade.findMemberById(
+        Member findMember = memberQueryFacade.findById(
                 authenticatedMember.getAuthenticatedIdAsValue()
         );
 
         return ResponseEntity.ok(MemberProfileResponse.of(findMember));
+    }
+
+    @GetMapping("/{memberId}/hover-info")
+    public ResponseEntity<MemberInformationHoverResponse> findMemberById(@PathVariable Long memberId) {
+
+        Member findMember = memberQueryFacade.findById(
+                MemberId.from(memberId)
+        );
+
+        return ResponseEntity.ok(MemberInformationHoverResponse.of(findMember));
     }
 
     @GetMapping
@@ -41,7 +53,7 @@ public class MemberQueryController {
             return ResponseEntity.notFound().build();
         }
 
-        Member findMember = memberQueryFacade.findMemberByNickName(
+        Member findMember = memberQueryFacade.findByNickName(
                 NickName.from(nickName)
         );
 

--- a/backend/src/main/java/com/example/backend/business/web/reaction/facade/ReactionCommandFacade.java
+++ b/backend/src/main/java/com/example/backend/business/web/reaction/facade/ReactionCommandFacade.java
@@ -38,7 +38,7 @@ public class ReactionCommandFacade {
                                CommentId commentId,
                                CommentReactionEmotion commentReactionEmotion) {
 
-        Member findMember = memberQueryService.findMemberById(memberId).orElseThrow(()->new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+        Member findMember = memberQueryService.findById(memberId).orElseThrow(()->new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
         Comment findComment = commentQueryServices.findCommentById(commentId).orElseThrow(()->new BusinessException(COMMENT_NOT_FOUND_EXCEPTION));
         Study findStudy = studyQueryFacade.findStudyById(studyId).orElseThrow(() -> new BusinessException(STUDY_NOT_FOUND_EXCEPTION));
         ReactionClicked reactionClicked = reactionQueryService.exist(memberId, commentId, commentReactionEmotion);

--- a/backend/src/main/java/com/example/backend/business/web/study/facade/StudyCommandFacade.java
+++ b/backend/src/main/java/com/example/backend/business/web/study/facade/StudyCommandFacade.java
@@ -53,7 +53,7 @@ public class StudyCommandFacade {
                              Study study,
                              TagNames tagNames) {
 
-        Member studyLeader = memberQueryService.findMemberById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+        Member studyLeader = memberQueryService.findById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
 
         Study newStudy = studyCommandService.save(study);
         newStudy.registerMember(studyLeader);
@@ -106,7 +106,7 @@ public class StudyCommandFacade {
                             MaxStudyMemberCount maxStudyMemberCount,
                             Milestone milestone) {
 
-        Member studyLeader = memberQueryService.findMemberById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+        Member studyLeader = memberQueryService.findById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
         Study findStudy = studyQueryServices.findStudyById(studyId).orElseThrow(() -> new BusinessException(STUDY_NOT_FOUND_EXCEPTION));
         findStudy.validateStudyLeader(studyLeader);
 
@@ -132,7 +132,7 @@ public class StudyCommandFacade {
 
     @Transactional
     public void deleteStudy(MemberId memberId, StudyId studyId) {
-        Member writer = memberQueryService.findMemberById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+        Member writer = memberQueryService.findById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
         Study findStudy = studyQueryServices.findStudyById(studyId).orElseThrow(() -> new BusinessException(STUDY_NOT_FOUND_EXCEPTION));
         studyCommandService.deleteStudy(writer, findStudy);
     }
@@ -163,7 +163,7 @@ public class StudyCommandFacade {
 
     @Transactional
     public void updateStudyStatus(MemberId memberId, StudyId studyId, StudyStatus studyStatus) {
-        Member studyLeader = memberQueryService.findMemberById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
+        Member studyLeader = memberQueryService.findById(memberId).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
         Study findStudy = studyQueryServices.findStudyById(studyId).orElseThrow(() -> new BusinessException(STUDY_NOT_FOUND_EXCEPTION));
         studyCommandService.updateStudyStatus(studyLeader, findStudy, studyStatus);
     }


### PR DESCRIPTION
## 📌 상세내용
&nbsp;- Member 레이어에 Follow와 관련된 메서드가 함께 존재해서 `역할과 책임을 나누기 위해 별도의 Follow 레이어로 분리`
&nbsp;- Member 레이어의 메서드 이름 중 Member가 붙은 메서드 변경.   ex) findMemberById -> findById
<br/>

&nbsp;&nbsp;&nbsp; closed issue #1