### PR TITLE
refactor: 댓글을 Query에서 읽어오도록 변경

### DIFF
--- a/backend/src/main/java/com/example/backend/business/web/comment/application/CommentCommandService.java
+++ b/backend/src/main/java/com/example/backend/business/web/comment/application/CommentCommandService.java
@@ -21,7 +21,7 @@ import static com.example.backend.common.exception.comment.CommentNotFoundExcept
 @RequiredArgsConstructor
 public class CommentCommandService {
 
-    private final CommentQueryDslQueryRepository commentCommandRepository;
+    private final CommentQueryDslQueryRepository commentQueryDslQueryRepository;
     private final CommentQueryDslCommandRepository commentQueryDslCommandRepository;
 
     @Transactional
@@ -41,7 +41,7 @@ public class CommentCommandService {
                                   CommentParentId commentParentId,
                                   CommentContent content) {
 
-        Comment findCommentParent = commentCommandRepository.findCommentByParentId(commentParentId).orElseThrow(()->new BusinessException(COMMENT_NOT_FOUND_EXCEPTION));
+        Comment findCommentParent = commentQueryDslQueryRepository.findByParentId(commentParentId).orElseThrow(()->new BusinessException(COMMENT_NOT_FOUND_EXCEPTION));
         Study findStudy = findCommentParent.getStudy();
 
         Comment newComment = Comment.writeReComment(writer, findStudy, content, commentParentId);
@@ -56,11 +56,11 @@ public class CommentCommandService {
                               CommentId commentId,
                               CommentContent content) {
 
-        Comment findComment = commentCommandRepository.findCommentById(commentId).orElseThrow(()->new BusinessException(COMMENT_NOT_FOUND_EXCEPTION));
+        Comment findComment = commentQueryDslQueryRepository.findById(commentId).orElseThrow(()->new BusinessException(COMMENT_NOT_FOUND_EXCEPTION));
 
         if (findComment.hasParentId()) {
             findComment.updateContent(memberId, content);
-            commentCommandRepository.exist(CommentParentId.from(findComment.getCommentParentId()));
+            commentQueryDslQueryRepository.exist(CommentParentId.from(findComment.getCommentParentId()));
             return;
         }
 
@@ -72,14 +72,14 @@ public class CommentCommandService {
                                 CommentId commentId,
                                 CommentContent content) {
 
-        Comment findReComment = commentCommandRepository.findCommentById(commentId).orElseThrow(()->new BusinessException(COMMENT_NOT_FOUND_EXCEPTION));
+        Comment findReComment = commentQueryDslQueryRepository.findById(commentId).orElseThrow(()->new BusinessException(COMMENT_NOT_FOUND_EXCEPTION));
 
         findReComment.updateContent(memberId, content);
     }
 
     @Transactional
     public void deleteComment(MemberId memberId, CommentId commentId) {
-        Comment findComment = commentCommandRepository.findCommentById(commentId).orElseThrow(()->new BusinessException(COMMENT_NOT_FOUND_EXCEPTION));
+        Comment findComment = commentQueryDslQueryRepository.findById(commentId).orElseThrow(()->new BusinessException(COMMENT_NOT_FOUND_EXCEPTION));
         Study findStudy = findComment.getStudy();
 
         findComment.delete(memberId);
@@ -91,8 +91,8 @@ public class CommentCommandService {
                                 CommentParentId commentParentId,
                                 CommentId commentId) {
 
-        Comment findComment = commentCommandRepository.findCommentByParentId(commentParentId).orElseThrow(()->new BusinessException(COMMENT_NOT_FOUND_EXCEPTION));
-        Comment findRecomment = commentCommandRepository.findCommentById(commentId).orElseThrow(()->new BusinessException(COMMENT_PARENT_NOT_FOUND_EXCEPTION));
+        Comment findComment = commentQueryDslQueryRepository.findByParentId(commentParentId).orElseThrow(()->new BusinessException(COMMENT_PARENT_NOT_FOUND_EXCEPTION));
+        Comment findRecomment = commentQueryDslQueryRepository.findById(commentId).orElseThrow(()->new BusinessException(COMMENT_NOT_FOUND_EXCEPTION));
         Study findStudy = findRecomment.getStudy();
 
         findRecomment.delete(memberId);

--- a/backend/src/main/java/com/example/backend/business/web/comment/presentation/CommentCommandController.java
+++ b/backend/src/main/java/com/example/backend/business/web/comment/presentation/CommentCommandController.java
@@ -16,7 +16,6 @@ import com.example.backend.business.web.comment.presentation.dto.response.Commen
 import com.example.backend.common.login.annotation.Authenticated;
 import com.example.backend.common.login.model.authentication.AuthenticatedMember;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,6 +24,8 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.CREATED;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,7 +44,7 @@ public class CommentCommandController {
                 CommentContent.from(request.getContent())
         );
 
-        return new ResponseEntity<>(CommentWriteResponse.of(newComment), HttpStatus.CREATED);
+        return new ResponseEntity<>(CommentWriteResponse.of(newComment), CREATED);
     }
 
     @PostMapping("/{commentId}/recomments")
@@ -57,7 +58,7 @@ public class CommentCommandController {
                 CommentContent.from(request.getContent())
         );
 
-        return new ResponseEntity<>(CommentReWriteResponse.of(newReComment), HttpStatus.CREATED);
+        return new ResponseEntity<>(CommentReWriteResponse.of(newReComment), CREATED);
     }
 
     @PutMapping("/{commentId}")
@@ -100,7 +101,7 @@ public class CommentCommandController {
                 CommentId.from(commentId)
         );
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/{commentParentId}/recomments/{commentId}")
@@ -116,6 +117,6 @@ public class CommentCommandController {
                 CommentId.from(commentId)
         );
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/example/backend/business/web/comment/presentation/CommentQueryController.java
+++ b/backend/src/main/java/com/example/backend/business/web/comment/presentation/CommentQueryController.java
@@ -26,11 +26,25 @@ public class CommentQueryController {
     private final CommentQueryFacade commentQueryFacade;
 
     @GetMapping("/study/{studyId}")
-    public ResponseEntity<CustomSlice<CommentResponse>> findCommentsByStudyId(@PathVariable Long studyId,
-                                                                              Pageable pageable,
-                                                                              HttpServletRequest httpServletRequest) {
+    public ResponseEntity<CustomSlice<CommentResponse>> findById(@PathVariable Long studyId,
+                                                                 Pageable pageable,
+                                                                 HttpServletRequest httpServletRequest) {
 
-        CustomSlice<CommentResponse> response = commentQueryFacade.findCommentsByStudyId(
+        CustomSlice<CommentResponse> response = commentQueryFacade.findById(
+                getMemberId(httpServletRequest),
+                StudyId.from(studyId),
+                pageable
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/study/{studyId}/v2")
+    public ResponseEntity<CommentPageResponse> findByV2(@PathVariable Long studyId,
+                                                        Pageable pageable,
+                                                        HttpServletRequest httpServletRequest) {
+
+        CommentPageResponse response = commentQueryFacade.findByIdV2(
                 getMemberId(httpServletRequest),
                 StudyId.from(studyId),
                 pageable
@@ -40,27 +54,13 @@ public class CommentQueryController {
     }
 
     @GetMapping("/commentParent/{commentParentId}")
-    public ResponseEntity<CustomSlice<CommentResponse>> findCommentsByParentId(@PathVariable Long commentParentId,
-                                                                               Pageable pageable,
-                                                                               HttpServletRequest httpServletRequest) {
-
-        CustomSlice<CommentResponse> response = commentQueryFacade.findCommentsByParentId(
-                getMemberId(httpServletRequest),
-                CommentParentId.from(commentParentId),
-                pageable
-        );
-
-        return ResponseEntity.ok(response);
-    }
-
-    @GetMapping("/study/{studyId}/v2")
-    public ResponseEntity<CommentPageResponse> findCommentsByStudyIdV2(@PathVariable Long studyId,
+    public ResponseEntity<CustomSlice<CommentResponse>> findByParentId(@PathVariable Long commentParentId,
                                                                        Pageable pageable,
                                                                        HttpServletRequest httpServletRequest) {
 
-        CommentPageResponse response = commentQueryFacade.findCommentsByStudyIdV2(
+        CustomSlice<CommentResponse> response = commentQueryFacade.findByParentId(
                 getMemberId(httpServletRequest),
-                StudyId.from(studyId),
+                CommentParentId.from(commentParentId),
                 pageable
         );
 

--- a/backend/src/main/java/com/example/backend/business/web/member/application/member/MemberQueryService.java
+++ b/backend/src/main/java/com/example/backend/business/web/member/application/member/MemberQueryService.java
@@ -34,11 +34,6 @@ public class MemberQueryService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<Member> findMemberAndStudyJoinRequestsById(MemberId memberId) {
-        return memberQueryDslQueryRepository.findStudyJoinRequestsById(memberId);
-    }
-
-    @Transactional(readOnly = true)
     public NickNameExistResponse validateDuplicatedNickName(NickName nickName) {
         return memberQueryDslQueryRepository.validateDuplicatedNickName(nickName);
     }

--- a/backend/src/main/java/com/example/backend/business/web/reaction/facade/ReactionCommandFacade.java
+++ b/backend/src/main/java/com/example/backend/business/web/reaction/facade/ReactionCommandFacade.java
@@ -39,7 +39,7 @@ public class ReactionCommandFacade {
                                CommentReactionEmotion commentReactionEmotion) {
 
         Member findMember = memberQueryService.findById(memberId).orElseThrow(()->new BusinessException(MEMBER_NOT_FOUND_EXCEPTION));
-        Comment findComment = commentQueryServices.findCommentById(commentId).orElseThrow(()->new BusinessException(COMMENT_NOT_FOUND_EXCEPTION));
+        Comment findComment = commentQueryServices.findById(commentId).orElseThrow(()->new BusinessException(COMMENT_NOT_FOUND_EXCEPTION));
         Study findStudy = studyQueryFacade.findById(studyId).orElseThrow(() -> new BusinessException(STUDY_NOT_FOUND_EXCEPTION));
         ReactionClicked reactionClicked = reactionQueryService.exist(memberId, commentId, commentReactionEmotion);
 

--- a/backend/src/test/java/com/example/backend/lshare/business/presentation/comment/CommentPagingApiTest.java
+++ b/backend/src/test/java/com/example/backend/lshare/business/presentation/comment/CommentPagingApiTest.java
@@ -42,7 +42,7 @@ package com.example.backend.lshare.business.presentation.comment;//package com.e
 //        List<CommentResponse> content = List.of(commentResponse);
 //        Pageable pageable = PageRequest.of(0, 10);
 //
-//        when(commentQueryFacade.findCommentsByStudyId(anyLong(), StudyId.from(anyLong()), any()))
+//        when(commentQueryFacade.findByIds(anyLong(), StudyId.from(anyLong()), any()))
 //                .thenReturn(new CustomSlice<>(new SliceImpl<>(content, pageable, true)));
 //
 //        mockMvc.perform(get("/api/comments/study/{studyId}", 1L)


### PR DESCRIPTION
## 📌 상세내용

&nbsp;- 댓글을 Query에서 읽어오도록 변경
&nbsp;- 메서드 이름 간단히 변경 ex) findCommentById -> findById
&nbsp;- CommentQueryRepository 변경

<br/>

&nbsp;&nbsp;&nbsp; closed issue #11  