### PR TITLE
fix: 커서페이징에서 커서가 제대로 동작하지 않는 이슈를 해결한다.

### DIFF
--- a/backend/src/main/java/com/example/backend/business/core/common/values/CursorTarget.java
+++ b/backend/src/main/java/com/example/backend/business/core/common/values/CursorTarget.java
@@ -12,7 +12,7 @@ public class CursorTarget {
     }
 
     private void validateNext(Long next) {
-        if (!Objects.isNull(next)) {
+        if (!Objects.isNull(next) && next > Long.MIN_VALUE) {
             throw new IllegalArgumentException("올바른 페이지 번호를 입력해주세요.");
         }
     }


### PR DESCRIPTION
## 📌 상세내용

&nbsp;- 커서의 NotNull 조건을 제거해서 팔로워 목록을 불러올때 오류가 나던 것을 해결


<br/>

&nbsp;&nbsp;&nbsp; closed issue #32 